### PR TITLE
Feat/triggers

### DIFF
--- a/age_upd_event.sql
+++ b/age_upd_event.sql
@@ -1,0 +1,11 @@
+-- reminder to enable event scheduler with
+-- SET GLOBAL event_scheduler = ON;
+
+CREATE EVENT update_age_and_minor_status
+ON SCHEDULE EVERY 1 DAY
+STARTS '2025-08-04 00:00:00'
+DO
+  UPDATE club_members
+  SET 
+    age = TIMESTAMPDIFF(YEAR, date_of_birth, CURDATE()),
+    is_minor = IF(TIMESTAMPDIFF(YEAR, date_of_birth, CURDATE()) < 18, TRUE, FALSE);

--- a/age_upd_event.sql
+++ b/age_upd_event.sql
@@ -8,4 +8,4 @@ DO
   UPDATE club_members
   SET 
     age = TIMESTAMPDIFF(YEAR, date_of_birth, CURDATE()),
-    is_minor = IF(TIMESTAMPDIFF(YEAR, date_of_birth, CURDATE()) < 18, TRUE, FALSE);
+    is_minor = IF(TIMESTAMPDIFF(YEAR, date_of_birth, CURDATE()) < 18, 1, 0);

--- a/coach_trigger.sql
+++ b/coach_trigger.sql
@@ -1,0 +1,18 @@
+-- can check if exists with SHOW TRIGGERS;
+
+DELIMITER $$
+
+CREATE TRIGGER validate_coach_id
+BEFORE INSERT ON teams
+FOR EACH ROW
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM personnel
+    WHERE employee_id = NEW.coach_id AND role = 'coach'
+  ) THEN
+    SIGNAL SQLSTATE '45000'
+    SET MESSAGE_TEXT = 'coach_id must reference an employee with role = coach';
+  END IF;
+END$$
+
+DELIMITER ;

--- a/vw_undefeated.sql
+++ b/vw_undefeated.sql
@@ -5,8 +5,8 @@ USE ftc353_1;
     This view generates a report of all active club members who have never lost a game they where they played
 */
 
-DROP VIEW IF EXISTS fam_coach;
-CREATE VIEW fam_coach AS
+DROP VIEW IF EXISTS undefeated;
+CREATE VIEW undefeated AS
 
 WITH
     membership_list AS (


### PR DESCRIPTION
- Fixed name for `undefeated` view -> had same name as another view and was being overwritten. Already fixed in DB server
- Added trigger on insertion to check whether `coach_id` belongs to an employee with the coach role
- Added global event to recalculate age and recheck `is_minor` attribute based on `date_of_birth` every 24 hours.